### PR TITLE
SVG-Branding-Logo wurde nicht geladen, wenn Frontend durch maintenance-AddOn gesperrt war.

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -108,7 +108,7 @@ if (!function_exists('checkExtension')) {
 				return $be_logo;
 				}
 			if ($ext === "svg" ) {
-				$be_logo = '/media/' . $filename;
+				$be_logo = 'index.php?rex_media_type=ORIGINAL_' . hash("md5", $filename) . '&rex_media_file=' . $filename;
 				return $be_logo;
 				}
 		}// EoF


### PR DESCRIPTION
Fehler: Wenn das Frontend durch das maintenance-AddOn gesperrt ist und im be_branding-AddOn ein SCG als Branding-Logo ausgewählt ist, konnte die SVG nicht ausgegeben werden.

Lösung: Bei Aufruf der Backend-Login-Seite wird ein Branding-Logo vom Typ SVG nun über die index.php vom Backend ausgegeben. Dabei wird das Fallback vom Medienmanager genutzt, wenn ein nicht-existierender Medientyp verwendet wird. In diesem Fall wird die Original-Datei ausgegeben.